### PR TITLE
Feature 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 List of changes between versions
 
+## 0.3.2
+
+- Fixed an issue with websites that impose a `text-indent` on the image original class (inherited by the wrapper div and thus the wrapped text)
+  EG: some sites use a `.preload` class on the image which has a `text-indent: -9999px` style causing the text to render out of the visible area
+  Forcing tha `patch-text` to have a `text-indent: 0` style fixes this issue and should have no side effects on other elements iun the page
+  
 ## 0.3.1
 
 - Added this file

--- a/extension/content.css
+++ b/extension/content.css
@@ -40,6 +40,7 @@
 
 .ocr-wrapped ~ .patch-text {
     z-index: 50000;
+    text-indent: 0;
     position: absolute;
     visibility: visible;
     background-color: var(--ocr-text-bg-color);

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
 
   "manifest_version": 2,
   "name": "OCR_extension",
-  "version": "0.3.1",
+  "version": "0.3.2",
 
   "description": "A browser extension working with a backend server running OCR+translation to in-place translate all images on an active tab.",
 


### PR DESCRIPTION
Minor patch addressing https://github.com/Crivella/ocr_translate/issues/51

Fixed an issue with websites that impose a `text-indent` on the image original class (inherited by the wrapper div and thus the wrapped text)
  EG: some sites use a `.preload` class on the image which has a `text-indent: -9999px` style causing the text to render out of the visible area
  Forcing tha `patch-text` to have a `text-indent: 0` style fixes this issue and should have no side effects on other elements iun the page